### PR TITLE
Added BLDEF support

### DIFF
--- a/mercury_engine_data_structures/formats/__init__.py
+++ b/mercury_engine_data_structures/formats/__init__.py
@@ -1,6 +1,7 @@
 from typing import Type
 
 from mercury_engine_data_structures.formats.base_resource import BaseResource, AssetType
+from mercury_engine_data_structures.formats.bldef import Bldef
 from mercury_engine_data_structures.formats.bmbls import Bmbls
 from mercury_engine_data_structures.formats.bmmap import Bmmap
 from mercury_engine_data_structures.formats.bmmdef import Bmmdef
@@ -22,6 +23,7 @@ from mercury_engine_data_structures.formats.gui_files import Bmscp, Bmssk, Bmsss
 
 ALL_FORMATS = {
     "PKG": Pkg,
+    "BLDEF": Bldef,
     "BMBLS": Bmbls,
     "BMMAP": Bmmap,
     "BMMDEF": Bmmdef,

--- a/mercury_engine_data_structures/formats/bldef.py
+++ b/mercury_engine_data_structures/formats/bldef.py
@@ -1,31 +1,15 @@
 from construct import Construct, Container, Struct, Const, Int32ul, Terminated, Hex
 
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats import BaseResource, standard_format
 from mercury_engine_data_structures.formats.property_enum import PropertyEnum
 from mercury_engine_data_structures.game_check import Game
 from mercury_engine_data_structures import type_lib
 
-BLDEF = Struct(
-    # the file uses CLightManager type but then has it as a field inside pLightComponent. 
-    # the inside field is the one that type_lib can handle, this is basically a modified version of standard_format.create
-    class_crc=Const('CLightManager', PropertyEnum),
-    version=Const(0x02000001, Hex(Int32ul)),
-
-    _root_type=Const('Root', PropertyEnum),
-    _root_len=Const(1, Int32ul),
-
-    _lm_field=Const('pLightManager', PropertyEnum),
-    _lm_type=Const('CLightManager', PropertyEnum),
-    pLightManager=type_lib.get_type('CLightManager').construct,
-    _end=Terminated,
-)
-
-
 class Bldef(BaseResource):
     @classmethod
     def construct_class(cls, target_game: Game) -> Construct:
-        return BLDEF
+        return standard_format.game_model('CLightManager', 0x02000001)
     
     @property
     def lightdefs(self) -> Container:
-        return self.raw.LightManager.dicLightDefs
+        return self.raw.Root.pLightManager.dicLightDefs

--- a/mercury_engine_data_structures/formats/bldef.py
+++ b/mercury_engine_data_structures/formats/bldef.py
@@ -1,0 +1,31 @@
+from construct import Construct, Container, Struct, Const, Int32ul, Terminated, Hex
+
+from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.property_enum import PropertyEnum
+from mercury_engine_data_structures.game_check import Game
+from mercury_engine_data_structures import type_lib
+
+BLDEF = Struct(
+    # the file uses CLightManager type but then has it as a field inside pLightComponent. 
+    # the inside field is the one that type_lib can handle, this is basically a modified version of standard_format.create
+    class_crc=Const('CLightManager', PropertyEnum),
+    version=Const(0x02000001, Hex(Int32ul)),
+
+    _root_type=Const('Root', PropertyEnum),
+    _root_len=Const(1, Int32ul),
+
+    _lm_field=Const('pLightManager', PropertyEnum),
+    _lm_type=Const('CLightManager', PropertyEnum),
+    pLightManager=type_lib.get_type('CLightManager').construct,
+    _end=Terminated,
+)
+
+
+class Bldef(BaseResource):
+    @classmethod
+    def construct_class(cls, target_game: Game) -> Construct:
+        return BLDEF
+    
+    @property
+    def lightdefs(self) -> Container:
+        return self.raw.LightManager.dicLightDefs


### PR DESCRIPTION
Adds support to open BLDEF (Light Definition/CLightManager) files. 

These have a bit of a weird format -- they have similar structure to `standard_format` files but there are two types of CLightManager. One is an outer one that contains version string, the Root element, and a field `pLightManager: CLightManager`. `standard_format.create()` doesn't like this since there isn't a `pLightManager` data type, so I copied and modified the function so it won't try to match `pLightManager` to a type. 

I'm not sure if the other params in `standard_format.create()` would let us get around that, so review appreciated :]