### PR TITLE
Support for Bmtre, Bmslink, Bmslgroup

### DIFF
--- a/mercury_engine_data_structures/file_tree_editor.py
+++ b/mercury_engine_data_structures/file_tree_editor.py
@@ -324,6 +324,10 @@ class FileTreeEditor:
                 self._toc.add_file(asset_id, len(data))
                 if None in self._files_for_asset_id[asset_id] or output_format == OutputFormat.ROMFS:
                     path = self._name_for_asset_id[asset_id]
+                    if path.endswith(".bmmap"):
+                        if None in self._files_for_asset_id[asset_id]:
+                            logger.warning("Requested that %s be written to romfs", path)
+                        continue
                     logger.info("Writing to %s with %d bytes", path, len(data))
                     _write_to_path(output_path.joinpath(path), data)
                     if self._files_for_asset_id[asset_id] - {None}:

--- a/mercury_engine_data_structures/formats/__init__.py
+++ b/mercury_engine_data_structures/formats/__init__.py
@@ -8,6 +8,7 @@ from mercury_engine_data_structures.formats.bmsad import Bmsad
 from mercury_engine_data_structures.formats.bmscc import Bmscc
 from mercury_engine_data_structures.formats.bmscu import Bmscu
 from mercury_engine_data_structures.formats.bmsld import Bmsld
+from mercury_engine_data_structures.formats.bmslgroup import Bmslgroup
 from mercury_engine_data_structures.formats.bmssd import Bmssd
 from mercury_engine_data_structures.formats.brem import Brem
 from mercury_engine_data_structures.formats.bres import Bres
@@ -35,6 +36,7 @@ ALL_FORMATS = {
     "BMSCD": Bmscc,
     "BMSCU": Bmscu,
     "BMSLD": Bmsld,
+    "BMSLGROUP": Bmslgroup,
     "BRSA": Brsa,
     "BREM": Brem,
     "BRES": Bres,

--- a/mercury_engine_data_structures/formats/__init__.py
+++ b/mercury_engine_data_structures/formats/__init__.py
@@ -32,6 +32,7 @@ ALL_FORMATS = {
     "BMSAD": Bmsad,
     "BRFLD": Brfld,
     "BMSCC": Bmscc,
+    "BMSCD": Bmscc,
     "BMSCU": Bmscu,
     "BMSLD": Bmsld,
     "BRSA": Brsa,

--- a/mercury_engine_data_structures/formats/__init__.py
+++ b/mercury_engine_data_structures/formats/__init__.py
@@ -10,6 +10,7 @@ from mercury_engine_data_structures.formats.bmscu import Bmscu
 from mercury_engine_data_structures.formats.bmsld import Bmsld
 from mercury_engine_data_structures.formats.bmslgroup import Bmslgroup
 from mercury_engine_data_structures.formats.bmssd import Bmssd
+from mercury_engine_data_structures.formats.bmtre import Bmtre
 from mercury_engine_data_structures.formats.brem import Brem
 from mercury_engine_data_structures.formats.bres import Bres
 from mercury_engine_data_structures.formats.brev import Brev
@@ -37,6 +38,7 @@ ALL_FORMATS = {
     "BMSCU": Bmscu,
     "BMSLD": Bmsld,
     "BMSLGROUP": Bmslgroup,
+    "BMTRE": Bmtre,
     "BRSA": Brsa,
     "BREM": Brem,
     "BRES": Bres,

--- a/mercury_engine_data_structures/formats/__init__.py
+++ b/mercury_engine_data_structures/formats/__init__.py
@@ -9,6 +9,7 @@ from mercury_engine_data_structures.formats.bmscc import Bmscc
 from mercury_engine_data_structures.formats.bmscu import Bmscu
 from mercury_engine_data_structures.formats.bmsld import Bmsld
 from mercury_engine_data_structures.formats.bmslgroup import Bmslgroup
+from mercury_engine_data_structures.formats.bmslink import Bmslink
 from mercury_engine_data_structures.formats.bmssd import Bmssd
 from mercury_engine_data_structures.formats.bmtre import Bmtre
 from mercury_engine_data_structures.formats.brem import Brem
@@ -38,6 +39,7 @@ ALL_FORMATS = {
     "BMSCU": Bmscu,
     "BMSLD": Bmsld,
     "BMSLGROUP": Bmslgroup,
+    "BMSLINK": Bmslink,
     "BMTRE": Bmtre,
     "BRSA": Brsa,
     "BREM": Brem,

--- a/mercury_engine_data_structures/formats/bmslgroup.py
+++ b/mercury_engine_data_structures/formats/bmslgroup.py
@@ -1,0 +1,12 @@
+import construct
+
+from mercury_engine_data_structures.formats import BaseResource, standard_format
+from mercury_engine_data_structures.game_check import Game
+
+BMSLGROUP = standard_format.create('navmesh::CDynamicSmartLinkGroup', 0x02000001)
+
+
+class Bmslgroup(BaseResource):
+    @classmethod
+    def construct_class(cls, target_game: Game) -> construct.Construct:
+        return BMSLGROUP

--- a/mercury_engine_data_structures/formats/bmslink.py
+++ b/mercury_engine_data_structures/formats/bmslink.py
@@ -1,0 +1,60 @@
+import construct
+
+from construct import Construct, Container, ListContainer
+from construct.core import (PrefixedArray, Byte, Const, Flag, Hex, Int32ul, Struct, )
+
+from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.common_types import StrId, Float
+from mercury_engine_data_structures.game_check import Game
+
+UnkStruct = Struct(
+    unk1 = StrId,
+    unk2 = Byte,
+    unk3 = Float,
+    unk4 = StrId,
+    unk5 = StrId,
+    unk6 = Float,
+    unk7 = Byte,
+    unk8 = StrId,
+    unk9 = Int32ul,
+    
+)
+
+Item = Struct(
+    name = StrId,
+    type = StrId,
+    unk1 = StrId,
+    unk2 = Float,
+    unk3 = StrId,   
+    unk4 = Float,
+    unk5 = StrId,
+    unk6 = Byte,
+    unk7 = Byte,
+    unk8 = StrId,
+    unk9 = Byte,
+    unk10 = Byte,
+    unk11 = Byte,
+    unk12 = Float,
+    unk13 = UnkStruct,
+    unk14 = UnkStruct,
+    unk15 = UnkStruct,
+)
+
+LocationStruct = Struct(
+    name = StrId,
+    itemCount = Int32ul,
+    items = Item
+)
+
+BMSLINK = Struct(
+    _magic = Const(b"LINK"),
+    version = Const(0x001F0001, Hex(Int32ul)),
+
+    unk_bool = Byte,
+    location = LocationStruct,
+)
+
+class Bmslink(BaseResource):
+    @classmethod
+    def construct_class(cls, target_game: Game) -> Construct:
+        return BMSLINK

--- a/mercury_engine_data_structures/formats/bmslink.py
+++ b/mercury_engine_data_structures/formats/bmslink.py
@@ -1,7 +1,7 @@
 import construct
 
 from construct import Construct, Container, ListContainer
-from construct.core import (PrefixedArray, Byte, Const, Flag, Hex, Int32ul, LazyBound, Struct, )
+from construct.core import (PrefixedArray, Byte, Const, Flag, Hex, If, Int32ul, LazyBound, Struct, )
 
 from mercury_engine_data_structures.formats import BaseResource
 from mercury_engine_data_structures.common_types import StrId, Float
@@ -15,7 +15,10 @@ UnkStruct = Struct(
     unk5 = StrId,
     unk6 = Float,
     unk7 = Byte,
-    unk8 = StrId,
+    unk8 = construct.core.If(
+        construct.this.unk5 != "Portal",
+        StrId,
+    ),
     children = PrefixedArray(Int32ul, LazyBound(lambda: UnkStruct))
 )
 

--- a/mercury_engine_data_structures/formats/bmslink.py
+++ b/mercury_engine_data_structures/formats/bmslink.py
@@ -1,7 +1,7 @@
 import construct
 
 from construct import Construct, Container, ListContainer
-from construct.core import (PrefixedArray, Byte, Const, Flag, Hex, Int32ul, Struct, )
+from construct.core import (PrefixedArray, Byte, Const, Flag, Hex, Int32ul, LazyBound, Struct, )
 
 from mercury_engine_data_structures.formats import BaseResource
 from mercury_engine_data_structures.common_types import StrId, Float
@@ -16,8 +16,7 @@ UnkStruct = Struct(
     unk6 = Float,
     unk7 = Byte,
     unk8 = StrId,
-    unk9 = Int32ul,
-    
+    children = PrefixedArray(Int32ul, LazyBound(lambda: UnkStruct))
 )
 
 Item = Struct(
@@ -36,14 +35,11 @@ Item = Struct(
     unk11 = Byte,
     unk12 = Float,
     unk13 = UnkStruct,
-    unk14 = UnkStruct,
-    unk15 = UnkStruct,
 )
 
 LocationStruct = Struct(
     name = StrId,
-    itemCount = Int32ul,
-    items = Item
+    items = PrefixedArray(Int32ul, Item)
 )
 
 BMSLINK = Struct(

--- a/mercury_engine_data_structures/formats/bmtre.py
+++ b/mercury_engine_data_structures/formats/bmtre.py
@@ -1,0 +1,67 @@
+import construct
+from construct.core import (
+    Array, Byte, Const, Construct, Flag, Float32l, Hex, If, Int16ul, Int32ul, Int32sl, Int64ul, LazyBound, PrefixedArray, Select, Struct, Switch, IfThenElse
+)
+
+from mercury_engine_data_structures import common_types, type_lib
+from mercury_engine_data_structures import game_check
+from mercury_engine_data_structures.common_types import Float, StrId, make_dict, make_vector
+from mercury_engine_data_structures.construct_extensions.alignment import PrefixedAllowZeroLen
+from mercury_engine_data_structures.construct_extensions.misc import ErrorWithMessage
+from mercury_engine_data_structures.formats import BaseResource, dread_types
+from mercury_engine_data_structures.formats.property_enum import PropertyEnum
+from mercury_engine_data_structures.game_check import Game
+
+StrKeyArgument = Struct(
+    key = StrId,
+    val = Switch(
+        construct.this.key[0],
+        {
+            'b': Flag,
+            's': StrId,
+            'f': Float,
+            'u': Int32ul,
+            'i': Int32sl,
+            'e': Int32ul,
+            'o': Int32ul,
+            'v': Array(3, Float)
+        },
+        default = construct.Error
+    )
+)
+
+CrcKeyArgument = Struct(
+    key = PropertyEnum,
+    val = Switch(
+        construct.this.key[0],
+        {
+            'b': Flag,
+            's': StrId,
+            'f': Float,
+            'u': Int32ul,
+            'i': Int32sl,
+            'e': StrId,
+            'o': Int32ul,
+            'v': Array(3, Float)
+        },
+        default = construct.Error
+    )
+)
+
+Behavior = Struct(
+    type = Select(PropertyEnum, Hex(Int64ul)),
+    args = PrefixedArray(Int32ul, CrcKeyArgument),
+    children = PrefixedArray(Int32ul, LazyBound(lambda: Behavior)),
+)
+
+BMTRE = Struct(
+    _magic = Const(b"BTRE"),
+    version = Const(0x00050001, Hex(Int32ul)), # for dread, unsure if it exists in SR
+    args = PrefixedArray(Int32ul, StrKeyArgument),
+    behavior = Behavior,
+)
+
+class Bmtre(BaseResource):
+    @classmethod
+    def construct_class(cls, target_game: Game) -> Construct:
+        return BMTRE

--- a/mercury_engine_data_structures/formats/bmtre.py
+++ b/mercury_engine_data_structures/formats/bmtre.py
@@ -1,6 +1,6 @@
 import construct
 from construct.core import (
-    Array, Byte, Const, Construct, Flag, Float32l, Hex, If, Int16ul, Int32ul, Int32sl, Int64ul, LazyBound, PrefixedArray, Select, Struct, Switch, IfThenElse
+    Array, Byte, Const, Construct, Container, Flag, Float32l, Hex, If, Int16ul, Int32ul, Int32sl, Int64ul, LazyBound, PrefixedArray, Select, Struct, Switch, IfThenElse
 )
 
 from mercury_engine_data_structures import common_types, type_lib
@@ -12,21 +12,23 @@ from mercury_engine_data_structures.formats import BaseResource, dread_types
 from mercury_engine_data_structures.formats.property_enum import PropertyEnum
 from mercury_engine_data_structures.game_check import Game
 
+ArgumentCases = {
+    'b': Flag,
+    's': StrId,
+    'f': Float,
+    'u': Int32ul,
+    'i': Int32sl,
+    'e': StrId,
+    'o': Int32ul,
+    'v': Array(3, Float)
+}
+
 StrKeyArgument = Struct(
     key = StrId,
     val = Switch(
         construct.this.key[0],
-        {
-            'b': Flag,
-            's': StrId,
-            'f': Float,
-            'u': Int32ul,
-            'i': Int32sl,
-            'e': Int32ul,
-            'o': Int32ul,
-            'v': Array(3, Float)
-        },
-        default = construct.Error
+        ArgumentCases,
+        construct.Error
     )
 )
 
@@ -34,17 +36,8 @@ CrcKeyArgument = Struct(
     key = PropertyEnum,
     val = Switch(
         construct.this.key[0],
-        {
-            'b': Flag,
-            's': StrId,
-            'f': Float,
-            'u': Int32ul,
-            'i': Int32sl,
-            'e': StrId,
-            'o': Int32ul,
-            'v': Array(3, Float)
-        },
-        default = construct.Error
+        ArgumentCases,
+        construct.Error
     )
 )
 
@@ -61,7 +54,73 @@ BMTRE = Struct(
     behavior = Behavior,
 )
 
+
+
 class Bmtre(BaseResource):
     @classmethod
     def construct_class(cls, target_game: Game) -> Construct:
         return BMTRE
+    
+    # private func to print a line in the pretty printer
+    def _pretty_print_line(self, text: str, depth: int) -> None:
+        print('    ' * depth + text)
+
+    # private func to print a string's type and args
+    def _type_and_args_string(self, behavior: Container) -> str:
+        res: str = behavior.type
+        if len(behavior.args) > 0:
+            res += " ("
+            for arg in behavior.args:
+                res += f"{arg.key}={arg.val}, "
+            res = res[:-2] # remove the last comma
+            res += ")"
+        res = res[14:] # remove "behaviortree::" from start
+        return res
+
+    # private func to pretty-print a behaviortree element
+    def _pretty_print_behavior(self, behavior: Container, depth: int) -> None:
+        match behavior.type:
+            # Repeats the behavior of its child regardless of success or failure
+            case "behaviortree::CRepeat":
+                self._pretty_print_line(f"Repeat behavior:", depth)
+                self._pretty_print_behavior(behavior.children[0], depth+1)
+            
+            # if the first child returns success, runs the second child. otherwise runs the third child. 
+            case "behaviortree::CIf":
+                self._pretty_print_line(f"If:", depth)
+                self._pretty_print_behavior(behavior.children[0], depth+1)
+                self._pretty_print_line("Then:", depth)
+                self._pretty_print_behavior(behavior.children[1], depth+1)
+                self._pretty_print_line("Else:", depth)
+                self._pretty_print_behavior(behavior.children[2], depth+1)
+            
+            # runs children in sequence until one fails, then returns to parent
+            case "behaviortree::CSequence":
+                self._pretty_print_line("Sequence:", depth)
+                for child in behavior.children:
+                    self._pretty_print_behavior(child, depth+1)
+            
+            # runs children in sequence until one succeeds, then returns to parent
+            case "behaviortree::CSelector":
+                self._pretty_print_line("Selector:", depth)
+                for child in behavior.children:
+                    self._pretty_print_behavior(child, depth+1)
+            
+            # runs *all* children in parallel until all succeed or one fails. if one fails, it terminates all other children and returns to parent
+            case "behaviortree::CParallel":
+                self._pretty_print_line("Parallel:", depth)
+                for child in behavior.children:
+                    self._pretty_print_behavior(child, depth+1)
+
+            case _:
+                self._pretty_print_line(self._type_and_args_string(behavior), depth)
+
+    # pretty-prints the tree in a more human-readable format
+    def print_tree(self) -> None:
+        # print global arguments
+        if len(self.raw.args) > 0:
+            for arg in self.raw.args:
+                self._pretty_print_line(f"{arg.key} = {arg.val}", 0)
+
+        # print behaviors
+        self._pretty_print_behavior(self.raw.behavior, 0)

--- a/mercury_engine_data_structures/formats/bmtre.py
+++ b/mercury_engine_data_structures/formats/bmtre.py
@@ -79,41 +79,40 @@ class Bmtre(BaseResource):
 
     # private func to pretty-print a behaviortree element
     def _pretty_print_behavior(self, behavior: Container, depth: int) -> None:
-        match behavior.type:
-            # Repeats the behavior of its child regardless of success or failure
-            case "behaviortree::CRepeat":
-                self._pretty_print_line(f"Repeat behavior:", depth)
-                self._pretty_print_behavior(behavior.children[0], depth+1)
-            
-            # if the first child returns success, runs the second child. otherwise runs the third child. 
-            case "behaviortree::CIf":
-                self._pretty_print_line(f"If:", depth)
-                self._pretty_print_behavior(behavior.children[0], depth+1)
-                self._pretty_print_line("Then:", depth)
-                self._pretty_print_behavior(behavior.children[1], depth+1)
-                self._pretty_print_line("Else:", depth)
-                self._pretty_print_behavior(behavior.children[2], depth+1)
-            
-            # runs children in sequence until one fails, then returns to parent
-            case "behaviortree::CSequence":
-                self._pretty_print_line("Sequence:", depth)
-                for child in behavior.children:
-                    self._pretty_print_behavior(child, depth+1)
-            
-            # runs children in sequence until one succeeds, then returns to parent
-            case "behaviortree::CSelector":
-                self._pretty_print_line("Selector:", depth)
-                for child in behavior.children:
-                    self._pretty_print_behavior(child, depth+1)
-            
-            # runs *all* children in parallel until all succeed or one fails. if one fails, it terminates all other children and returns to parent
-            case "behaviortree::CParallel":
-                self._pretty_print_line("Parallel:", depth)
-                for child in behavior.children:
-                    self._pretty_print_behavior(child, depth+1)
+        # Repeats the behavior of its child regardless of success or failure
+        if behavior.type == "behaviortree::CRepeat":
+            self._pretty_print_line(f"Repeat behavior:", depth)
+            self._pretty_print_behavior(behavior.children[0], depth+1)
+        
+        # if the first child returns success, runs the second child. otherwise runs the third child. 
+        elif behavior.type ==  "behaviortree::CIf":
+            self._pretty_print_line(f"If:", depth)
+            self._pretty_print_behavior(behavior.children[0], depth+1)
+            self._pretty_print_line("Then:", depth)
+            self._pretty_print_behavior(behavior.children[1], depth+1)
+            self._pretty_print_line("Else:", depth)
+            self._pretty_print_behavior(behavior.children[2], depth+1)
+        
+        # runs children in sequence until one fails, then returns to parent
+        elif behavior.type ==  "behaviortree::CSequence":
+            self._pretty_print_line("Sequence:", depth)
+            for child in behavior.children:
+                self._pretty_print_behavior(child, depth+1)
+        
+        # runs children in sequence until one succeeds, then returns to parent
+        elif behavior.type ==  "behaviortree::CSelector":
+            self._pretty_print_line("Selector:", depth)
+            for child in behavior.children:
+                self._pretty_print_behavior(child, depth+1)
+        
+        # runs *all* children in parallel until all succeed or one fails. if one fails, it terminates all other children and returns to parent
+        elif behavior.type ==  "behaviortree::CParallel":
+            self._pretty_print_line("Parallel:", depth)
+            for child in behavior.children:
+                self._pretty_print_behavior(child, depth+1)
 
-            case _:
-                self._pretty_print_line(self._type_and_args_string(behavior), depth)
+        else:
+            self._pretty_print_line(self._type_and_args_string(behavior), depth)
 
     # pretty-prints the tree in a more human-readable format
     def print_tree(self) -> None:


### PR DESCRIPTION
Bmtre's are behavior trees; parsing is implemented and includes a `Bmtre.print_tree()` function that pretty-prints using the control nodes in behaviortree namespace (CRepeat, CIf, CSequence, CSelector, CParallel). 

Bmslgroup's are a standard format that references a bmslink file. 

Bmslink's are a non-standard format that connects actors with the navmesh. This is largely used for entities that travel along walls, such as Emmys, Autclasts, Infesters and Saboturu. It can parse all files currently, but I'm not sure what most of the parameters are; I would appreciate review to see if anyone can figure out what is going on. 