### PR TITLE
Remove PYTHONWARNINGS=error during build

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -34,7 +34,9 @@ jobs:
         run: python -m pip install --upgrade build
 
       - name: build
-        run: PYTHONWARNINGS=error python -m build
+        # Not adding PYTHONWARNINGS=error as it can trigger errors in pip itself
+        # See https://github.com/pypa/pip/issues/12243
+        run: python -m build
 
       - name: Store the packages
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
build uses pip to install dependencies, and pip raises a deprecation warning (see https://github.com/pypa/pip/issues/12243).