### PR TITLE
Apply alignment after header in pkg

### DIFF
--- a/src/mercury_engine_data_structures/formats/pkg.py
+++ b/src/mercury_engine_data_structures/formats/pkg.py
@@ -17,7 +17,7 @@ from construct import (
 from mercury_engine_data_structures import dread_data, samus_returns_data
 from mercury_engine_data_structures.construct_extensions.alignment import AlignTo
 from mercury_engine_data_structures.formats.base_resource import AssetId, BaseResource, NameOrAssetId, resolve_asset_id
-from mercury_engine_data_structures.game_check import Game, get_current_game
+from mercury_engine_data_structures.game_check import Game
 
 
 def _file_entry(target_game: Game):
@@ -73,9 +73,8 @@ class PkgConstruct(construct.Construct):
         # Get the file headers
         file_headers = self.file_headers_type._parsereport(stream, context, path)
 
-        if get_current_game(context) == Game.DREAD:
-            # Align to 128 bytes
-            AlignTo(128)._parsereport(stream, context, path)
+        # Align to 128 bytes
+        AlignTo(128)._parsereport(stream, context, path)
 
         files = construct.ListContainer()
         for i, header in enumerate(file_headers):
@@ -99,9 +98,8 @@ class PkgConstruct(construct.Construct):
         # Skip over file headers
         construct.stream_seek(stream, len(obj.files) * file_entry_size, 1, path)
 
-        if get_current_game(context) == Game.DREAD:
-            # Align to 128 bytes
-            AlignTo(128)._build(None, stream, context, path)
+        # Align to 128 bytes
+        AlignTo(128)._build(None, stream, context, path)
 
         header_end = construct.stream_tell(stream, path)
 


### PR DESCRIPTION
No idea how to provide tests due to the fact that the padding within the pkg looks totally random. (some pkg's even have odd number of bytes)