### PR TITLE
Rename bmsbk field

### DIFF
--- a/src/mercury_engine_data_structures/formats/bmsbk.py
+++ b/src/mercury_engine_data_structures/formats/bmsbk.py
@@ -22,7 +22,7 @@ Block = Struct(
     "pos" / CVector3D,
     "unk2" / Int32ul,
     "unk3" / Int32ul,
-    "unk4" / Float32l,
+    "respawn_time" / Float32l,
     "name1" / StrId,
     "name2" / StrId,
 )


### PR DESCRIPTION
According to DCR `unk4` is the respawn time for the blocks, where 0.0 means it nevers respawn and if greater than 0.0 it's the time in seconds.

@dyceron Are there other fields we could rename? There was a "always visible" thing but I don't know to which field it was related.