### PR TITLE
Rename unknown, add all_actors method

### DIFF
--- a/src/mercury_engine_data_structures/formats/bmsld.py
+++ b/src/mercury_engine_data_structures/formats/bmsld.py
@@ -4,7 +4,7 @@ from typing import Iterator, Tuple
 import construct
 from construct import Const, Construct, Container, Flag, Float32l, Hex, Int32ul, Struct, Switch
 
-from mercury_engine_data_structures.common_types import Float, StrId, make_dict, make_vector
+from mercury_engine_data_structures.common_types import CVector3D, Float, StrId, make_dict, make_vector
 from mercury_engine_data_structures.construct_extensions.misc import ErrorWithMessage
 from mercury_engine_data_structures.formats import BaseResource
 from mercury_engine_data_structures.formats.collision import collision_formats
@@ -52,12 +52,8 @@ Components = {
 ProperActor = Struct(
     type=StrId,
 
-    x=Float,
-    y=Float,
-    z=Float,
-    x_rotation=Float32l,
-    y_rotation=Float32l,
-    z_rotation=Float32l,
+    position=CVector3D,
+    rotation=CVector3D,
     components=make_vector(Struct(
         component_type=StrId,
         command=StrId,

--- a/src/mercury_engine_data_structures/formats/bmsld.py
+++ b/src/mercury_engine_data_structures/formats/bmsld.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Iterator
+from typing import Iterator, Tuple
 
 import construct
 from construct import Const, Construct, Container, Flag, Float32l, Hex, Int32ul, Struct, Switch
@@ -55,10 +55,9 @@ ProperActor = Struct(
     x=Float,
     y=Float,
     z=Float,
-    unk05=Hex(Int32ul),
-    unk06=Hex(Int32ul),
-    unk07=Hex(Int32ul),
-
+    x_rotation=Float32l,
+    y_rotation=Float32l,
+    z_rotation=Float32l,
     components=make_vector(Struct(
         component_type=StrId,
         command=StrId,
@@ -148,6 +147,11 @@ class Bmsld(BaseResource):
     @classmethod
     def construct_class(cls, target_game: Game) -> Construct:
         return BMSLD
+
+    def all_actors(self) -> Iterator[Tuple[int, str, construct.Container]]:
+        for layer in self.raw.actors:
+            for actor_name, actor in layer.items():
+                yield layer, actor_name, actor
 
     def all_actor_groups(self) -> Iterator[tuple[str, Container]]:
         for sub_area in self.raw.sub_areas:

--- a/src/mercury_engine_data_structures/samus_returns_types.json
+++ b/src/mercury_engine_data_structures/samus_returns_types.json
@@ -1353,12 +1353,8 @@
         "parent": "CGameObject",
         "fields": {
             "type": "base::global::StrId",
-            "x": "float",
-            "y": "float",
-            "z": "float",
-            "unk05": "unsigned",
-            "unk06": "unsigned",
-            "unk07": "unsigned",
+            "position": "base::math::CVector3D",
+            "rotation": "base::math::CVector3D",
             "components": "base::global::CRntVector<Component>"
         }
     },
@@ -1409,5 +1405,9 @@
     "unsigned": {
         "kind": "primitive",
         "primitive_kind": "uint"
+    },
+    "base::math::CVector3D": {
+        "kind": "primitive",
+        "primitive_kind": "float_vec3"
     }
 }

--- a/tests/formats/test_bmsld.py
+++ b/tests/formats/test_bmsld.py
@@ -60,6 +60,10 @@ def test_get_actor_group(surface_bmsld: Bmsld):
     with pytest.raises(KeyError):
         surface_bmsld.get_actor_group("blabla")
 
+def test_all_actors(surface_bmsld: Bmsld):
+    all_actors = list(surface_bmsld.all_actors())
+    assert len(all_actors) == 232
+
 def test_all_actor_group_names_for_actor(surface_bmsld: Bmsld):
     groups = surface_bmsld.all_actor_group_names_for_actor("LE_EnergyRecharge")
     assert groups == [


### PR DESCRIPTION
Rotating a shield around y-axis:
0: ![0](https://github.com/randovania/mercury-engine-data-structures/assets/117127188/c93e6d37-e0e7-4b31-afd7-edd0078848df)
90 (I use this for now as a "cheat" to at least have it wrongly visible on both sides):
![90](https://github.com/randovania/mercury-engine-data-structures/assets/117127188/171069f6-5b81-428f-8c79-43f1a4f3fd7f)
180: ![180](https://github.com/randovania/mercury-engine-data-structures/assets/117127188/a1748280-1e0a-468d-9c5e-48c13e4a0f15)
