### PR TITLE
Write pkgs with only ensured assets

### DIFF
--- a/src/mercury_engine_data_structures/file_tree_editor.py
+++ b/src/mercury_engine_data_structures/file_tree_editor.py
@@ -314,6 +314,12 @@ class FileTreeEditor:
         for asset_id in self._modified_resources.keys():
             modified_pkgs.update(self._files_for_asset_id[asset_id])
 
+        # Ensure pkgs are written which only have new ensured assets without
+        # completly new assets
+        for key, asset_ids in self._ensured_asset_ids.items():
+            if len(asset_ids) != 0:
+                modified_pkgs.add(key)
+
         if None in modified_pkgs:
             modified_pkgs.remove(None)
 


### PR DESCRIPTION
In `save_modifications` MEDS is creating a `modified_pkgs` set but it only adds a pkg to the set, if you have modified ressources or have added ressources to it but not if you only have used the `ensure_present` method. The last method only adds it to `_ensured_asset_ids`, so it is reasonable to iterate through it and add these pkgs.

This is relevant for MSR as it has a `AREA_NAME.pkg` but also a `AREA_NAME_discardables.pkg`. In the first one we ensure all the models, animations etc., while the second contains the scenario BRFLD, lua files and BMSAD.

Let's hope that nothing breaks for Dread (but we are using RomFS export anyways now?)