### PR TITLE
Add support for BMSMSD

### DIFF
--- a/src/mercury_engine_data_structures/formats/__init__.py
+++ b/src/mercury_engine_data_structures/formats/__init__.py
@@ -14,6 +14,7 @@ from mercury_engine_data_structures.formats.bmscu import Bmscu
 from mercury_engine_data_structures.formats.bmsld import Bmsld
 from mercury_engine_data_structures.formats.bmslgroup import Bmslgroup
 from mercury_engine_data_structures.formats.bmslink import Bmslink
+from mercury_engine_data_structures.formats.bmsmsd import Bmsmsd
 from mercury_engine_data_structures.formats.bmsnav import Bmsnav
 from mercury_engine_data_structures.formats.bmssd import Bmssd
 from mercury_engine_data_structures.formats.bmtre import Bmtre
@@ -50,6 +51,7 @@ ALL_FORMATS = {
     "BMSCD": Bmscc,
     "BMSCU": Bmscu,
     "BMSLD": Bmsld,
+    "BMSMSD": Bmsmsd,
     "BMSNAV": Bmsnav,
     "BMSLGROUP": Bmslgroup,
     "BMSLINK": Bmslink,

--- a/src/mercury_engine_data_structures/formats/bmsmsd.py
+++ b/src/mercury_engine_data_structures/formats/bmsmsd.py
@@ -12,8 +12,7 @@ BMSMSD = Struct(
     "_magic" / Const(b"MMSD"),
     "version" / Const(0x00070001, Hex(Int32ul)),
     "scenario" / StrId,
-    "unk1" / Float32l,
-    "unk2" / Float32l,
+    "tile_size" / construct.Array(2, Float32l),
     "x_tiles" / Int32sl,
     "y_tiles" / Int32sl,
     "dimension" / Struct(
@@ -27,14 +26,14 @@ BMSMSD = Struct(
                 "bottom_left" / CVector2D,
                 "top_right" / CVector2D,
             ),
-            "unk3" / Int32sl,
-            "unk4" / Int32sl,
+            "border_type" / Int32sl,
+            "tile_type" / Int32sl,
             "icons" / make_vector(
                 Struct(
                     "actor_name" / StrId,
-                    "item_id" / StrId,
+                    "clear_condition" / StrId,
                     "icon" / StrId,
-                    "unk5" / Int32sl,
+                    "icon_priority" / Int32sl,
                     "coordinates" / CVector3D,
                 )
             ),

--- a/src/mercury_engine_data_structures/formats/bmsmsd.py
+++ b/src/mercury_engine_data_structures/formats/bmsmsd.py
@@ -1,0 +1,51 @@
+import functools
+
+import construct
+from construct.core import Const, Construct, Float32l, Hex, Int32sl, Int32ul, Struct
+
+from mercury_engine_data_structures.common_types import CVector2D, CVector3D, StrId, make_vector
+from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.game_check import Game
+
+# BMSMSD
+BMSMSD = Struct(
+    "_magic" / Const(b"MMSD"),
+    "version" / Const(0x00070001, Hex(Int32ul)),
+    "scenario" / StrId,
+    "unk1" / Float32l,
+    "unk2" / Float32l,
+    "x_tiles" / Int32sl,
+    "y_tiles" / Int32sl,
+    "dimension" / Struct(
+        "bottom_left" / CVector2D,
+        "top_right" / CVector2D,
+    ),
+    "tiles" / make_vector(
+        Struct(
+            "tile_coordinates" / construct.Array(2, Int32sl),
+            "dimension" / Struct(
+                "bottom_left" / CVector2D,
+                "top_right" / CVector2D,
+            ),
+            "unk3" / Int32sl,
+            "unk4" / Int32sl,
+            "icons" / make_vector(
+                Struct(
+                    "actor_name" / StrId,
+                    "item_id" / StrId,
+                    "icon" / StrId,
+                    "unk5" / Int32sl,
+                    "coordinates" / CVector3D,
+                )
+            ),
+        )
+    ),
+    construct.Terminated,
+)
+
+
+class Bmsmsd(BaseResource):
+    @classmethod
+    @functools.lru_cache
+    def construct_class(cls, target_game: Game) -> Construct:
+        return BMSMSD

--- a/src/mercury_engine_data_structures/formats/bmsmsd.py
+++ b/src/mercury_engine_data_structures/formats/bmsmsd.py
@@ -15,7 +15,7 @@ BMSMSD = Struct(
     "tile_size" / construct.Array(2, Float32l),
     "x_tiles" / Int32sl,
     "y_tiles" / Int32sl,
-    "dimension" / Struct(
+    "map_dimensions" / Struct(
         "bottom_left" / CVector2D,
         "top_right" / CVector2D,
     ),

--- a/tests/formats/test_bmsmsd.py
+++ b/tests/formats/test_bmsmsd.py
@@ -1,0 +1,13 @@
+import pytest
+from tests.test_lib import parse_build_compare_editor
+
+from mercury_engine_data_structures import samus_returns_data
+from mercury_engine_data_structures.formats.bmsmsd import Bmsmsd
+
+all_sr_bmsmsd = [name for name in samus_returns_data.all_name_to_asset_id().keys()
+                   if name.endswith(".bmsmsd")]
+
+
+@pytest.mark.parametrize("bmsmsd_path", all_sr_bmsmsd)
+def test_bmtun(samus_returns_tree, bmsmsd_path):
+    parse_build_compare_editor(Bmsmsd, samus_returns_tree, bmsmsd_path)


### PR DESCRIPTION
Oh look, a MEDS change for MSR.

Adds support for the minimap files.
`unk1` and `unk2` are always 800.0 in the files I looked at. Guess we can ignore it.
No clue about `unk3`, `unk4` `unk5`. Maybe some sort of type. Guess DCR finds it out when playing around with it 😛

I thought that `x_tiles` and `y_tiles` in the header part defines the dimension in tiles, which was matching really good (and still kinda does)...until I found a save station which uses a value one greater than defined. But it's still my best guess.
