### PR TITLE
Skip over correct length for the header in pkg files

### DIFF
--- a/src/mercury_engine_data_structures/formats/pkg.py
+++ b/src/mercury_engine_data_structures/formats/pkg.py
@@ -96,7 +96,7 @@ class PkgConstruct(construct.Construct):
         construct.stream_seek(stream, 2 * self.int_size.length, 1, path)
 
         # Skip over file headers
-        construct.stream_seek(stream, len(obj.files) * file_entry_size, 1, path)
+        construct.stream_seek(stream, self.int_size.length + len(obj.files) * file_entry_size, 1, path)
 
         # Align to 128 bytes
         AlignTo(128)._build(None, stream, context, path)


### PR DESCRIPTION
That's a fun one: The file header contains of `asset_id`, `start_offset` and `end_offset` for each file.
But it's an prefixed array and the 4 bytes for the length are missing when skipping over it via `stream_seek`.
When the pkg doesn't need alignment without the missing 4 bytes, the header will overwrite the first 4 bytes of an actual file, which you can see in SR here: https://user-images.githubusercontent.com/117127188/284011718-8a40aa69-8561-452e-b4fe-fdc09d9dd6c1.png

I don't know why I haven't seen it, when I added the alignment for SR because it was already visible there.