### PR TITLE
MSR - Fix file extraction

### DIFF
--- a/src/mercury_engine_data_structures/formats/pkg.py
+++ b/src/mercury_engine_data_structures/formats/pkg.py
@@ -74,8 +74,9 @@ class PkgConstruct(construct.Construct):
         # Get the file headers
         file_headers = self.file_headers_type._parsereport(stream, context, path)
 
-        # Align to 128 bytes
-        AlignTo(128)._parsereport(stream, context, path)
+        if self.game == Game.DREAD:
+            # Align to 128 bytes
+            AlignTo(128)._parsereport(stream, context, path)
 
         files = construct.ListContainer()
         for i, header in enumerate(file_headers):


### PR DESCRIPTION
Seems like this bit of code in `def _parse` breaks extraction. Reverting this change allows for extraction to properly occur, but I do not know the side effects or if this is the best way to fix this issue.

![image](https://github.com/randovania/mercury-engine-data-structures/assets/38679103/a9447885-4c9d-454e-a886-a8b2a465a9f4)

Leaving this PR as a draft for now until this is properly figured out.
