### PR TITLE
Try to tell self-host CI to use merge queue

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
      - main
+     - 'gh-readonly-queue/main/pr-**'
     tags:
       - '*'
 


### PR DESCRIPTION
![grafik](https://github.com/randovania/mercury-engine-data-structures/assets/38186597/6f382859-69b9-402f-bd89-1a4b7b4e180c)


Could be that because the runner only runs stuff on branches `main`, that it never gets to run the temporary merge queue branches.