### PR TITLE
Build vanilla PKGs in SR

### DIFF
--- a/tests/formats/test_pkg.py
+++ b/tests/formats/test_pkg.py
@@ -14,18 +14,59 @@ all_dread_pkg = [name for name in dread_data.all_name_to_asset_id().keys()
 all_sr_pkg = [name for name in samus_returns_data.all_name_to_asset_id().keys()
                    if name.endswith(".pkg")]
 
+wrong_build_sr = [
+    # MSCU, no padding in vanilla
+    "packs/cutscenes/elevator.pkg",
+    # MSCU, no padding in vanilla
+    "packs/cutscenes/teleporter.pkg",
+    # MSAT, padding of three 0 bytes in vanilla
+    "packs/maps/s020_area2/subareas/subarearp1_discardables.pkg",
+    # MSAT, padding of one 0 byte in vanilla
+    "packs/maps/s033_area3b/subareas/subarearp7_discardables.pkg",
+    # MSAT, padding of one 0 byte in vanilla
+    "packs/maps/s033_area3b/subareas/subarearp8_discardables.pkg",
+    # MSAT, padding of one 0 byte in vanilla
+    "packs/maps/s050_area5/subareas/subarearp4_discardables.pkg",
+    # MSAT, padding of one 0 byte in vanilla
+    "packs/maps/s060_area6/subareas/subarearp4_discardables.pkg",
+    # MSAT, padding of one 0 byte in vanilla
+    "packs/maps/s065_area6b/subareas/subarearp4_discardables.pkg",
+    # MSAT, padding of one 0 byte in vanilla
+    "packs/maps/s067_area6c/subareas/subarearp6_discardables.pkg",
+    # MTXT, no padding in vanilla
+    "packs/players/common.pkg",
+    # MTXT, no padding in vanilla
+    "packs/players/common_fusion.pkg",
+]
+
 @pytest.mark.parametrize("pkg_path", all_dread_pkg)
 def test_compare_dread(dread_path, pkg_path):
     parse_and_build_compare(
         Pkg.construct_class(Game.DREAD), Game.DREAD, dread_path.joinpath(pkg_path)
     )
 
-@pytest.mark.skip("Rebuilding vanilla pkg files is currently not supported for SR")
 @pytest.mark.parametrize("pkg_path", all_sr_pkg)
 def test_compare_sr(samus_returns_path, pkg_path):
-    parse_and_build_compare(
-        Pkg.construct_class(Game.SAMUS_RETURNS), Game.SAMUS_RETURNS, samus_returns_path.joinpath(pkg_path)
-    )
+    if pkg_path in wrong_build_sr:
+        raw = samus_returns_path.joinpath(pkg_path).read_bytes()
+        target_game = Game.SAMUS_RETURNS
+
+        module = Pkg.construct_class(target_game)
+        data = module.parse(raw, target_game=target_game)
+        encoded = module.build(data, target_game=target_game)
+
+        # compare up to the length field
+        assert raw[0:4] == encoded[0:4]
+
+        # compare after the length field until the end of bytes
+        # only to proof that only the ending has a random padding
+        min_len = min(len(raw), len(encoded))
+        assert raw[5:min_len] == encoded[5:min_len]
+        assert abs(len(raw) - len(encoded)) <= 3
+    else:
+        parse_and_build_compare(
+            Pkg.construct_class(Game.SAMUS_RETURNS), Game.SAMUS_RETURNS, samus_returns_path.joinpath(pkg_path)
+        )
 
 def test_build_empty_pkg():
     pkg = Pkg(Container(files=ListContainer()), Game.DREAD)


### PR DESCRIPTION
This is the code which can parse and rebuild all pkg files except 11 files. The only problem is the end of the file.
Always end with 0 padding at the end of the file except for `MSCU` `MTXT` `CUT ` which adds padding to align to 4 bytes.
- removing `MSCU` from special case => more files gonna fail
-  removing `MTXT` from special case => more files gonna fail
- adding `MSAT` to the special case => more files gonna fail

The `wrong_build_sr` case in the test is written in a weird way on purpose. It proofes that, of course, the length field is wrong but besides that it's only the ending which is wrong.

Don't know if it should merged 🤷‍♂️