### PR TITLE
Fixed AABOX2D collision

### DIFF
--- a/src/mercury_engine_data_structures/formats/collision.py
+++ b/src/mercury_engine_data_structures/formats/collision.py
@@ -20,7 +20,7 @@ CollisionPolySR = Struct(
 )
 CollisionPolyDread = Struct(
     num_points=Rebuild(UInt, construct.len_(construct.this.points)),
-    unk=Float,
+    unk=Hex(UInt),
     points=Array(construct.this.num_points, CollisionPoint),
     loop=Flag,
     boundings=Array(4, Float),
@@ -38,9 +38,9 @@ BinarySearchTree = Struct(
 
 collision_formats = {
     "AABOX2D": Struct(
-        unknown1=UInt,
-        min=CVector2D,
-        max=CVector2D,
+        center=CVector2D,
+        unk=Float,
+        size=CVector2D,
     ),
     "CIRCLE": Struct(
         value1=Float,


### PR DESCRIPTION
- Discovered that the AABOX2D format is not (unk, min, max) but is (center, unk, size)
- center is the "center" of the rect as an offset from the actor vPos
- size is the (w, h) of the box
- unk seems to be 0 in the examples i'm working with
- to render the box ( (cx, cy), u, (w, h) ), the coordinates are:
  - left: vPos.x + cx - w/2
  - right: vPos.x + cx + w/2
  - top: vPos.y + cy - h/2
  - bottom: vPos.y + cy + h/2

screenshots for evidence:

first artaria blob:
![image](https://github.com/randovania/mercury-engine-data-structures/assets/25016775/3fe333fb-b2d7-4d8f-b705-37563c194a36)
![image](https://github.com/randovania/mercury-engine-data-structures/assets/25016775/38f41bf5-5fcc-4267-b64b-e59248d71cf2)

cloak doors in corpius access (large box is  the sensor collider):
![image](https://github.com/randovania/mercury-engine-data-structures/assets/25016775/d8fe1f84-82aa-4e07-a8f8-c5e81524c997)
![image](https://github.com/randovania/mercury-engine-data-structures/assets/25016775/922e52af-a3cb-4d6d-ac7b-cf6488a679da)

screw attack room  spinner (boxes on the sides are the colliders to turn it, I assume  only the right is activated):
![image](https://github.com/randovania/mercury-engine-data-structures/assets/25016775/0cebad57-e5ea-490a-8a89-0095d35ff7a5)

hidden door in cataris below first EMMI entrance:
![image](https://github.com/randovania/mercury-engine-data-structures/assets/25016775/cd327f60-8480-4a87-a54f-831d0a5ec7d5)

Burenia hub to dairon, underwater blob section:
![image](https://github.com/randovania/mercury-engine-data-structures/assets/25016775/6e4f4a74-66f9-4446-a7c6-fd3c45fd92fb)
