### PR TITLE
Add BAPD

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Construct type definitions for Mercury Engine
 
 | Format    | Samus Returns (Read) | Samus Returns (Write) | Dread (Read) | Dread (Write) |
 |-----------|----------------------|-----------------------|--------------|---------------|
-| BAPD      | Missing              | Missing               | &cross;      | &cross;       |
+| BAPD      | Missing              | Missing               | &check;      | &check;       |
 | BCCAM     | &cross;              | &cross;               | &cross;      | &cross;       |
 | BCLGT     | &cross;              | &cross;               | Missing      | Missing       |
 | BCMDL     | &cross;              | &cross;               | &check;      | &cross;       |

--- a/src/mercury_engine_data_structures/formats/__init__.py
+++ b/src/mercury_engine_data_structures/formats/__init__.py
@@ -1,5 +1,6 @@
 from typing import Type
 
+from mercury_engine_data_structures.formats.bapd import Bapd
 from mercury_engine_data_structures.formats.base_resource import AssetType, BaseResource
 from mercury_engine_data_structures.formats.bcmdl import Bcmdl
 from mercury_engine_data_structures.formats.bctex import Bctex
@@ -40,6 +41,7 @@ from mercury_engine_data_structures.formats.txt import Txt
 
 ALL_FORMATS = {
     "PKG": Pkg,
+    "BAPD": Bapd,
     "BCMDL": Bcmdl,
     "BCTEX": Bctex,
     "BLDEF": Bldef,

--- a/src/mercury_engine_data_structures/formats/bapd.py
+++ b/src/mercury_engine_data_structures/formats/bapd.py
@@ -1,0 +1,13 @@
+import construct
+
+from mercury_engine_data_structures.formats.base_resource import BaseResource
+from mercury_engine_data_structures.formats.standard_format import game_model
+from mercury_engine_data_structures.game_check import Game
+
+BAPD = game_model('sound::CAudioPresets', 0x02030002)
+
+
+class Bapd(BaseResource):
+    @classmethod
+    def construct_class(cls, target_game: Game) -> construct.Construct:
+        return BAPD

--- a/tests/formats/test_bapd.py
+++ b/tests/formats/test_bapd.py
@@ -1,0 +1,13 @@
+import pytest
+from tests.test_lib import parse_build_compare_editor
+
+from mercury_engine_data_structures import dread_data
+from mercury_engine_data_structures.formats.bapd import Bapd
+
+all_dread_bapd = [name for name in dread_data.all_name_to_asset_id().keys()
+                   if name.endswith(".bapd")]
+
+
+@pytest.mark.parametrize("bapd_path", all_dread_bapd)
+def test_bmtre(dread_file_tree, bapd_path):
+    parse_build_compare_editor(Bapd, dread_file_tree, bapd_path)


### PR DESCRIPTION
- .bapd (audio preset) standard format file is parsed/built
- added test for all bapd files
- updated README
- made it more clear in formats submodule that any format imports must go BELOW BaseResource, even if they come first alphabetically