### PR TITLE
fixed potential circular imports in formats

### DIFF
--- a/src/mercury_engine_data_structures/formats/__init__.py
+++ b/src/mercury_engine_data_structures/formats/__init__.py
@@ -1,5 +1,6 @@
 from typing import Type
 
+from mercury_engine_data_structures.formats.base_resource import AssetType, BaseResource
 from mercury_engine_data_structures.formats.bcmdl import Bcmdl
 from mercury_engine_data_structures.formats.bctex import Bctex
 from mercury_engine_data_structures.formats.bldef import Bldef
@@ -36,7 +37,6 @@ from mercury_engine_data_structures.formats.lua import Lua
 from mercury_engine_data_structures.formats.pkg import Pkg
 from mercury_engine_data_structures.formats.toc import Toc
 from mercury_engine_data_structures.formats.txt import Txt
-from mercury_engine_data_structures.formats.base_resource import AssetType, BaseResource
 
 ALL_FORMATS = {
     "PKG": Pkg,

--- a/src/mercury_engine_data_structures/formats/__init__.py
+++ b/src/mercury_engine_data_structures/formats/__init__.py
@@ -1,6 +1,5 @@
 from typing import Type
 
-from mercury_engine_data_structures.formats.base_resource import AssetType, BaseResource
 from mercury_engine_data_structures.formats.bcmdl import Bcmdl
 from mercury_engine_data_structures.formats.bctex import Bctex
 from mercury_engine_data_structures.formats.bldef import Bldef
@@ -37,6 +36,7 @@ from mercury_engine_data_structures.formats.lua import Lua
 from mercury_engine_data_structures.formats.pkg import Pkg
 from mercury_engine_data_structures.formats.toc import Toc
 from mercury_engine_data_structures.formats.txt import Txt
+from mercury_engine_data_structures.formats.base_resource import AssetType, BaseResource
 
 ALL_FORMATS = {
     "PKG": Pkg,

--- a/src/mercury_engine_data_structures/formats/bcmdl.py
+++ b/src/mercury_engine_data_structures/formats/bcmdl.py
@@ -25,7 +25,7 @@ from construct.core import (
 )
 
 from mercury_engine_data_structures.common_types import Float, StrId
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 # Partial implementation to generate material variants

--- a/src/mercury_engine_data_structures/formats/bldef.py
+++ b/src/mercury_engine_data_structures/formats/bldef.py
@@ -1,6 +1,7 @@
 from construct import Construct, Container
 
-from mercury_engine_data_structures.formats import BaseResource, standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
+from mercury_engine_data_structures.formats import standard_format
 from mercury_engine_data_structures.game_check import Game
 
 

--- a/src/mercury_engine_data_structures/formats/bldef.py
+++ b/src/mercury_engine_data_structures/formats/bldef.py
@@ -1,7 +1,7 @@
 from construct import Construct, Container
 
-from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats import standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 

--- a/src/mercury_engine_data_structures/formats/blsnd.py
+++ b/src/mercury_engine_data_structures/formats/blsnd.py
@@ -11,7 +11,7 @@ from construct.core import (
 )
 
 from mercury_engine_data_structures.common_types import StrId, make_vector
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game, current_game_at_most
 
 BLSND = Struct(

--- a/src/mercury_engine_data_structures/formats/bmbls.py
+++ b/src/mercury_engine_data_structures/formats/bmbls.py
@@ -1,7 +1,7 @@
 import construct
 
-from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats import standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 BMBLS = standard_format.create('base::animation::CBlendSpaceResource', 0x02020001)

--- a/src/mercury_engine_data_structures/formats/bmbls.py
+++ b/src/mercury_engine_data_structures/formats/bmbls.py
@@ -1,6 +1,7 @@
 import construct
 
-from mercury_engine_data_structures.formats import BaseResource, standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
+from mercury_engine_data_structures.formats import standard_format
 from mercury_engine_data_structures.game_check import Game
 
 BMBLS = standard_format.create('base::animation::CBlendSpaceResource', 0x02020001)

--- a/src/mercury_engine_data_structures/formats/bmdefs.py
+++ b/src/mercury_engine_data_structures/formats/bmdefs.py
@@ -10,7 +10,7 @@ from construct import (
 )
 
 from mercury_engine_data_structures.common_types import StrId, make_vector
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 EnemyStruct = Struct(

--- a/src/mercury_engine_data_structures/formats/bmmap.py
+++ b/src/mercury_engine_data_structures/formats/bmmap.py
@@ -2,7 +2,8 @@ import functools
 
 from construct import Construct, Container
 
-from mercury_engine_data_structures.formats import BaseResource, standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
+from mercury_engine_data_structures.formats import standard_format
 from mercury_engine_data_structures.game_check import Game
 
 BMMAP = standard_format.create('CMinimapData', 0x02000001)

--- a/src/mercury_engine_data_structures/formats/bmmap.py
+++ b/src/mercury_engine_data_structures/formats/bmmap.py
@@ -2,8 +2,8 @@ import functools
 
 from construct import Construct, Container
 
-from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats import standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 BMMAP = standard_format.create('CMinimapData', 0x02000001)

--- a/src/mercury_engine_data_structures/formats/bmmdef.py
+++ b/src/mercury_engine_data_structures/formats/bmmdef.py
@@ -2,7 +2,8 @@ from typing import Tuple
 
 from construct import Construct, Container
 
-from mercury_engine_data_structures.formats import BaseResource, standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
+from mercury_engine_data_structures.formats import standard_format
 from mercury_engine_data_structures.game_check import Game
 
 BMMDEF = standard_format.create('CMinimapDef', 0x02000001)

--- a/src/mercury_engine_data_structures/formats/bmmdef.py
+++ b/src/mercury_engine_data_structures/formats/bmmdef.py
@@ -2,8 +2,8 @@ from typing import Tuple
 
 from construct import Construct, Container
 
-from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats import standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 BMMDEF = standard_format.create('CMinimapDef', 0x02000001)

--- a/src/mercury_engine_data_structures/formats/bmsad.py
+++ b/src/mercury_engine_data_structures/formats/bmsad.py
@@ -26,7 +26,7 @@ from mercury_engine_data_structures.common_types import Char, CVector3D, Float, 
 from mercury_engine_data_structures.construct_extensions.alignment import PrefixedAllowZeroLen
 from mercury_engine_data_structures.construct_extensions.function_complex import ComplexIf, SwitchComplexKey
 from mercury_engine_data_structures.construct_extensions.misc import ErrorWithMessage
-from mercury_engine_data_structures.formats import BaseResource, dread_types
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats.bmsas import BMSAS_SR, Bmsas
 from mercury_engine_data_structures.formats.property_enum import PropertyEnum
 from mercury_engine_data_structures.game_check import Game, GameSpecificStruct
@@ -80,6 +80,8 @@ ExtraFields = common_types.DictAdapter(make_vector(
 
 @functools.cache
 def fieldtypes(game: Game) -> dict[str, Construct]:
+    from mercury_engine_data_structures.formats import dread_types
+
     if game == Game.DREAD:
         return {k: v for k, v in vars(dread_types).items() if isinstance(v, Construct)}
     raise ValueError(f"No field types defined for {game}")

--- a/src/mercury_engine_data_structures/formats/bmsas.py
+++ b/src/mercury_engine_data_structures/formats/bmsas.py
@@ -20,7 +20,7 @@ from construct.core import (
 from mercury_engine_data_structures.common_types import Char, CVector3D, DictAdapter, Float, make_vector
 from mercury_engine_data_structures.common_types import StrId as StrIdSR
 from mercury_engine_data_structures.construct_extensions.strings import PascalStringRobust
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats.property_enum import PropertyEnum, PropertyEnumDoubleUnsafe
 from mercury_engine_data_structures.game_check import Game
 

--- a/src/mercury_engine_data_structures/formats/bmscc.py
+++ b/src/mercury_engine_data_structures/formats/bmscc.py
@@ -14,7 +14,7 @@ from construct import (
 from mercury_engine_data_structures import game_check
 from mercury_engine_data_structures.common_types import StrId, UInt, make_vector
 from mercury_engine_data_structures.construct_extensions.misc import ErrorWithMessage
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats.collision import collision_formats
 from mercury_engine_data_structures.game_check import Game
 

--- a/src/mercury_engine_data_structures/formats/bmscu.py
+++ b/src/mercury_engine_data_structures/formats/bmscu.py
@@ -1,7 +1,7 @@
 from construct import Construct
 
-from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats import standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 BMSCU = standard_format.create('CCutSceneDef', 0x02030008)

--- a/src/mercury_engine_data_structures/formats/bmscu.py
+++ b/src/mercury_engine_data_structures/formats/bmscu.py
@@ -1,6 +1,7 @@
 from construct import Construct
 
-from mercury_engine_data_structures.formats import BaseResource, standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
+from mercury_engine_data_structures.formats import standard_format
 from mercury_engine_data_structures.game_check import Game
 
 BMSCU = standard_format.create('CCutSceneDef', 0x02030008)

--- a/src/mercury_engine_data_structures/formats/bmsem.py
+++ b/src/mercury_engine_data_structures/formats/bmsem.py
@@ -9,7 +9,7 @@ from construct import (
 )
 
 from mercury_engine_data_structures.common_types import StrId, make_vector
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 BMSEM = Struct(

--- a/src/mercury_engine_data_structures/formats/bmses.py
+++ b/src/mercury_engine_data_structures/formats/bmses.py
@@ -12,7 +12,7 @@ from construct.core import (
 )
 
 from mercury_engine_data_structures.common_types import StrId, make_vector
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 BMSES = Struct(

--- a/src/mercury_engine_data_structures/formats/bmsld.py
+++ b/src/mercury_engine_data_structures/formats/bmsld.py
@@ -8,7 +8,7 @@ from mercury_engine_data_structures.common_types import CVector3D, Float, StrId,
 from mercury_engine_data_structures.construct_extensions.misc import ErrorWithMessage
 from mercury_engine_data_structures.construct_extensions.strings import StaticPaddedString
 from mercury_engine_data_structures.crc import crc32
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats.collision import collision_formats
 from mercury_engine_data_structures.game_check import Game
 

--- a/src/mercury_engine_data_structures/formats/bmslgroup.py
+++ b/src/mercury_engine_data_structures/formats/bmslgroup.py
@@ -1,6 +1,7 @@
 import construct
 
-from mercury_engine_data_structures.formats import BaseResource, standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
+from mercury_engine_data_structures.formats import standard_format
 from mercury_engine_data_structures.game_check import Game
 
 BMSLGROUP = standard_format.create('navmesh::CDynamicSmartLinkGroup', 0x02000001)

--- a/src/mercury_engine_data_structures/formats/bmslgroup.py
+++ b/src/mercury_engine_data_structures/formats/bmslgroup.py
@@ -1,7 +1,7 @@
 import construct
 
-from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats import standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 BMSLGROUP = standard_format.create('navmesh::CDynamicSmartLinkGroup', 0x02000001)

--- a/src/mercury_engine_data_structures/formats/bmslink.py
+++ b/src/mercury_engine_data_structures/formats/bmslink.py
@@ -11,7 +11,7 @@ from construct.core import (
 )
 
 from mercury_engine_data_structures.common_types import Float, StrId
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 UnkStruct = Struct(

--- a/src/mercury_engine_data_structures/formats/bmsmd.py
+++ b/src/mercury_engine_data_structures/formats/bmsmd.py
@@ -12,7 +12,7 @@ from construct.core import (
 )
 
 from mercury_engine_data_structures.common_types import StrId, make_vector
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 BMSMD = Struct(

--- a/src/mercury_engine_data_structures/formats/bmsmsd.py
+++ b/src/mercury_engine_data_structures/formats/bmsmsd.py
@@ -4,7 +4,7 @@ import construct
 from construct.core import Const, Construct, Enum, FlagsEnum, Float32l, Hex, Int32sl, Int32ul, Struct
 
 from mercury_engine_data_structures.common_types import CVector2D, CVector3D, StrId, make_vector
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 TileBorders = FlagsEnum(Int32sl,

--- a/src/mercury_engine_data_structures/formats/bmsnav.py
+++ b/src/mercury_engine_data_structures/formats/bmsnav.py
@@ -1,7 +1,7 @@
 from construct.core import Array, Byte, Const, Construct, Flag, Hex, Int32ul, PrefixedArray, Struct, Terminated
 
 from mercury_engine_data_structures.common_types import CVector2D, CVector3D, Float, StrId, make_dict
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 ### A ton of barely-understood structs :]

--- a/src/mercury_engine_data_structures/formats/bmssd.py
+++ b/src/mercury_engine_data_structures/formats/bmssd.py
@@ -12,7 +12,7 @@ from construct import (
 from mercury_engine_data_structures import game_check
 from mercury_engine_data_structures.common_types import CVector3D, StrId, make_vector
 from mercury_engine_data_structures.construct_extensions.strings import StaticPaddedString
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 BMSSD = Struct(

--- a/src/mercury_engine_data_structures/formats/bmtre.py
+++ b/src/mercury_engine_data_structures/formats/bmtre.py
@@ -15,7 +15,7 @@ from construct.core import (
 )
 
 from mercury_engine_data_structures.common_types import Float, StrId
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats.property_enum import PropertyEnum
 from mercury_engine_data_structures.game_check import Game
 

--- a/src/mercury_engine_data_structures/formats/bmtun.py
+++ b/src/mercury_engine_data_structures/formats/bmtun.py
@@ -14,7 +14,7 @@ from construct.core import (
 
 from mercury_engine_data_structures.common_types import Char, CVector3D, Float, StrId, make_dict
 from mercury_engine_data_structures.construct_extensions.misc import ErrorWithMessage
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 # Functions

--- a/src/mercury_engine_data_structures/formats/brem.py
+++ b/src/mercury_engine_data_structures/formats/brem.py
@@ -1,6 +1,7 @@
 import construct
 
-from mercury_engine_data_structures.formats import BaseResource, standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
+from mercury_engine_data_structures.formats import standard_format
 from mercury_engine_data_structures.game_check import Game
 
 

--- a/src/mercury_engine_data_structures/formats/brem.py
+++ b/src/mercury_engine_data_structures/formats/brem.py
@@ -1,7 +1,7 @@
 import construct
 
-from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats import standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 

--- a/src/mercury_engine_data_structures/formats/bres.py
+++ b/src/mercury_engine_data_structures/formats/bres.py
@@ -1,6 +1,7 @@
 import construct
 
-from mercury_engine_data_structures.formats import BaseResource, standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
+from mercury_engine_data_structures.formats import standard_format
 from mercury_engine_data_structures.game_check import Game
 
 

--- a/src/mercury_engine_data_structures/formats/bres.py
+++ b/src/mercury_engine_data_structures/formats/bres.py
@@ -1,7 +1,7 @@
 import construct
 
-from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats import standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 

--- a/src/mercury_engine_data_structures/formats/brev.py
+++ b/src/mercury_engine_data_structures/formats/brev.py
@@ -1,6 +1,7 @@
 import construct
 
-from mercury_engine_data_structures.formats import BaseResource, standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
+from mercury_engine_data_structures.formats import standard_format
 from mercury_engine_data_structures.game_check import Game
 
 

--- a/src/mercury_engine_data_structures/formats/brev.py
+++ b/src/mercury_engine_data_structures/formats/brev.py
@@ -1,7 +1,7 @@
 import construct
 
-from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats import standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 

--- a/src/mercury_engine_data_structures/formats/brfld.py
+++ b/src/mercury_engine_data_structures/formats/brfld.py
@@ -4,7 +4,8 @@ from typing import Iterator, List, Tuple
 
 import construct
 
-from mercury_engine_data_structures.formats import BaseResource, standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
+from mercury_engine_data_structures.formats import standard_format
 from mercury_engine_data_structures.game_check import Game
 
 logger = logging.getLogger(__name__)

--- a/src/mercury_engine_data_structures/formats/brfld.py
+++ b/src/mercury_engine_data_structures/formats/brfld.py
@@ -4,8 +4,8 @@ from typing import Iterator, List, Tuple
 
 import construct
 
-from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats import standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 logger = logging.getLogger(__name__)

--- a/src/mercury_engine_data_structures/formats/brsa.py
+++ b/src/mercury_engine_data_structures/formats/brsa.py
@@ -3,8 +3,8 @@ from typing import Iterator
 
 from construct import Construct, Container
 
-from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats import standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 

--- a/src/mercury_engine_data_structures/formats/brsa.py
+++ b/src/mercury_engine_data_structures/formats/brsa.py
@@ -3,7 +3,8 @@ from typing import Iterator
 
 from construct import Construct, Container
 
-from mercury_engine_data_structures.formats import BaseResource, standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
+from mercury_engine_data_structures.formats import standard_format
 from mercury_engine_data_structures.game_check import Game
 
 

--- a/src/mercury_engine_data_structures/formats/bsmat.py
+++ b/src/mercury_engine_data_structures/formats/bsmat.py
@@ -16,7 +16,7 @@ from construct.core import (
 )
 
 from mercury_engine_data_structures.common_types import Char, Float, StrId
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 # these seem to be using Unity ShaderLab, or at least the gist I borrowed this from uses similar teminology

--- a/src/mercury_engine_data_structures/formats/gui_files.py
+++ b/src/mercury_engine_data_structures/formats/gui_files.py
@@ -1,7 +1,7 @@
 from construct import Construct, Container
 
-from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.formats import standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 BMSCP = standard_format.create('GUI::CDisplayObjectContainer', 0x02020001, explicit_root=True)

--- a/src/mercury_engine_data_structures/formats/gui_files.py
+++ b/src/mercury_engine_data_structures/formats/gui_files.py
@@ -1,6 +1,7 @@
 from construct import Construct, Container
 
-from mercury_engine_data_structures.formats import BaseResource, standard_format
+from mercury_engine_data_structures.formats.base_resource import BaseResource
+from mercury_engine_data_structures.formats import standard_format
 from mercury_engine_data_structures.game_check import Game
 
 BMSCP = standard_format.create('GUI::CDisplayObjectContainer', 0x02020001, explicit_root=True)

--- a/src/mercury_engine_data_structures/formats/lua.py
+++ b/src/mercury_engine_data_structures/formats/lua.py
@@ -5,7 +5,7 @@ import typing
 import construct
 
 from mercury_engine_data_structures.common_types import StrId
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game
 
 if typing.TYPE_CHECKING:

--- a/src/mercury_engine_data_structures/formats/toc.py
+++ b/src/mercury_engine_data_structures/formats/toc.py
@@ -4,8 +4,7 @@ from typing import Iterator, Optional
 import construct
 
 from mercury_engine_data_structures import common_types
-from mercury_engine_data_structures.formats import BaseResource
-from mercury_engine_data_structures.formats.base_resource import NameOrAssetId, resolve_asset_id
+from mercury_engine_data_structures.formats.base_resource import BaseResource, NameOrAssetId, resolve_asset_id
 from mercury_engine_data_structures.game_check import Game
 
 TOC_SR = construct.Struct(

--- a/src/mercury_engine_data_structures/formats/txt.py
+++ b/src/mercury_engine_data_structures/formats/txt.py
@@ -6,7 +6,7 @@ from construct.core import Const, Construct, GreedyRange, Struct
 
 from mercury_engine_data_structures.common_types import DictAdapter, DictElement
 from mercury_engine_data_structures.construct_extensions.strings import CStringRobust
-from mercury_engine_data_structures.formats import BaseResource
+from mercury_engine_data_structures.formats.base_resource import BaseResource
 from mercury_engine_data_structures.game_check import Game, is_sr_or_else
 
 _string_range = GreedyRange(DictElement(CStringRobust("utf-16-le")))


### PR DESCRIPTION
- replaced "from mercury_engine_data_structures.formats import BaseResource" with "from mercury_engine_data_structures.formats.base_resource import BaseResource"
- replace "from mercury_engine_data_structures.formats import standard_format" with "from mercury_engine_data_structures.formats.standard_format import <create | game_model> and updated code to remove "standard_format." prefix