### PR TITLE
Repair encoding error in actors/props/pf_mushr_fr/charclasses/pf_mushr_fr.bmsad

### DIFF
--- a/tests/formats/test_bmsad.py
+++ b/tests/formats/test_bmsad.py
@@ -1,17 +1,12 @@
-import contextlib
-
-import construct
 import pytest
-from tests.test_lib import parse_build_compare_editor
+from tests.test_lib import parse_build_compare_editor, parse_build_compare_editor_parsed
 
 from mercury_engine_data_structures import dread_data, samus_returns_data
 from mercury_engine_data_structures.file_tree_editor import FileTreeEditor
 from mercury_engine_data_structures.formats import dread_types
 from mercury_engine_data_structures.formats.bmsad import ActorDefFunc, Bmsad
 
-expected_dread_failures = {
-    "actors/props/pf_mushr_fr/charclasses/pf_mushr_fr.bmsad",
-}
+dread_must_reencode = ["actors/props/pf_mushr_fr/charclasses/pf_mushr_fr.bmsad"]
 expected_sr_failures = set()
 
 sr_missing = [
@@ -357,12 +352,9 @@ sr_missing = [
 
 @pytest.mark.parametrize("bmsad_path", dread_data.all_files_ending_with(".bmsad"))
 def test_compare_dread_all(dread_file_tree, bmsad_path):
-    if bmsad_path in expected_dread_failures:
-        expectation = pytest.raises(construct.ConstructError)
+    if bmsad_path in dread_must_reencode:
+        parse_build_compare_editor_parsed(Bmsad, dread_file_tree, bmsad_path)
     else:
-        expectation = contextlib.nullcontext()
-
-    with expectation:
         parse_build_compare_editor(Bmsad, dread_file_tree, bmsad_path)
 
 


### PR DESCRIPTION
bmsad.py L270-L282 for non-formatting changes. 

- IfThenElse checks for a too-small component field length and replaces the correct value
- Throws an error on parsing if the size of a DreadComponent.fields is 0x1C and DreadComponent.fields.fields is not length 1 and an eDefaultCollisionMaterial
- applied / formatting to bmsad.py instead of = formatting in applicable locations
- updated tests to check parse-build-parse on this file